### PR TITLE
Fix the problem on collection create

### DIFF
--- a/src/middlewares/CollectionValidator.js
+++ b/src/middlewares/CollectionValidator.js
@@ -5,7 +5,7 @@ function CollectionValidator(req, res, next) {
     name: Joi.string().required(),
     shareOption: Joi.string().required().valid(['PUBLIC', 'PRIVATE', 'TEAM']),
     description: Joi.string().allow('', null),
-    teamId: Joi.number(),
+    teamId: Joi.number().allow(null, ''),
     sharedPermissions: Joi.string().valid(['READ', 'WRITE', 'DELETE']),
   });
   const result = Joi.validate(req.body, schema);


### PR DESCRIPTION
Fix the problem on collection validator that was rejecting a null on field. 

- Needed if the user wants to removes the sharing.